### PR TITLE
kraft.yaml: Update configuration to use Musl

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -20,12 +20,8 @@ targets:
   - architecture: arm64
     platform: kvm
 libraries:
-  pthread-embedded:
+  musl:
     version: stable
-  newlib:
-    version: stable
-    kconfig:
-      - CONFIG_LIBNEWLIBC=y
   sqlite:
     version: stable
     kconfig:

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -17,6 +17,8 @@ unikraft:
 targets:
   - architecture: x86_64
     platform: kvm
+  - architecture: arm64
+    platform: kvm
 libraries:
   pthread-embedded:
     version: stable


### PR DESCRIPTION
Update configuration to use Musl, instead of newlib and pthread-embedded